### PR TITLE
Add gitlab as OAuthService provider

### DIFF
--- a/flask_unchained/bundles/oauth/config.py
+++ b/flask_unchained/bundles/oauth/config.py
@@ -19,3 +19,12 @@ class Config(BundleConfig):
         request_token_url=None,
         request_token_params={'scope': 'profile:email'},
     )
+    
+    OAUTH_REMOTE_APP_GITLAB = dict(
+        base_url='https://gitlab.com/api/v4/user',
+        access_token_url='https://gitlab.com/oauth/token',
+        access_token_method='POST',
+        authorize_url='https://gitlab.com/oauth/authorize',
+        request_token_url=None,
+        request_token_params={'scope': 'openid read_user'},
+    )

--- a/flask_unchained/bundles/oauth/services.py
+++ b/flask_unchained/bundles/oauth/services.py
@@ -17,6 +17,9 @@ class OAuthService(BaseService):
         elif provider.name == 'github':
             data = provider.get('/user').data
             return data['email'], {}
+        elif provider.name == 'gitlab':
+            data = provider.get('user').data
+            return data['email'], {}
 
         raise NotImplementedError(f'Unknown OAuth remote app: {provider.name}')
 


### PR DESCRIPTION
Works with following provider in config.py
```python
OAUTH_REMOTE_APP_GITLAB = dict(
        consumer_key=os.getenv('OAUTH_GITLAB_CONSUMER_KEY', ''),
        consumer_secret=os.getenv('OAUTH_GITLAB_CONSUMER_SECRET', ''),
        base_url='https://gitlab.com/api/v4/user',
        access_token_url='https://gitlab.com/oauth/token',
        access_token_method='POST',
        authorize_url='https://gitlab.com/oauth/authorize',
        request_token_url=None,
        request_token_params={'scope': 'openid read_user'},
    )
```